### PR TITLE
Update FISH_CAUGHT_MESSAGE to let the punctuation be optional

### DIFF
--- a/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
+++ b/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
@@ -76,7 +76,7 @@ public class FishBarrelPlugin extends Plugin
 
 	// regex to recognize a chat message as an indicator of a caught fish
 	private static final Pattern FISH_CAUGHT_MESSAGE = Pattern.compile(
-		"^You catch (an?|some) ([a-zA-Z ]+)[.!]?( It hardens as you handle it with your ice gloves\\.)?$");
+		"^You catch (an?|some)(?: raw)? ([a-zA-Z ]+)[.!]?( It hardens as you handle it with your ice gloves\\.)?$");
 
 	private static final String RADA_DOUBLE_CATCH_MESSAGE = "Rada's blessing enabled you to catch an extra fish.";
 	private static final String FLAKES_DOUBLE_CATCH_MESSAGE = "The spirit flakes enabled you to catch an extra fish.";

--- a/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
+++ b/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
@@ -76,7 +76,7 @@ public class FishBarrelPlugin extends Plugin
 
 	// regex to recognize a chat message as an indicator of a caught fish
 	private static final Pattern FISH_CAUGHT_MESSAGE = Pattern.compile(
-		"^You catch (an?|some) ([a-zA-Z ]+)[.!]( It hardens as you handle it with your ice gloves\\.)?$");
+		"^You catch (an?|some) ([a-zA-Z ]+)[.!]?( It hardens as you handle it with your ice gloves\\.)?$");
 
 	private static final String RADA_DOUBLE_CATCH_MESSAGE = "Rada's blessing enabled you to catch an extra fish.";
 	private static final String FLAKES_DOUBLE_CATCH_MESSAGE = "The spirit flakes enabled you to catch an extra fish.";


### PR DESCRIPTION
The fish barrel was not updating for me when catching trout/salmon at Shilo, so I decided to look into the code.
I noticed that it was looking for a . or ! to match the caught fish message when that did not exist for me.
I made that punctuation optional, which will allow for anything that still uses it to pass while also working for the ones that don't.

Im not aware of the full process for runelite plugins, so im not sure if anything else needs updated.