### PR TITLE
Added toggle for notifying with a red infobox if RoL is not equipped

### DIFF
--- a/src/main/java/com/molopl/plugins/lifesaving/LifeSavingConfig.java
+++ b/src/main/java/com/molopl/plugins/lifesaving/LifeSavingConfig.java
@@ -43,7 +43,17 @@ public interface LifeSavingConfig extends Config
 		return true;
 	}
 
-	@ConfigItem(
+    @ConfigItem(
+            keyName = "ringOfLifeInfoboxOnlyNotEquipped",
+            name = "Ring of life infobox NOT equipped",
+            description = "Only show infobox when Ring of life is NOT equipped"
+    )
+    default boolean ringOfLifeInfoboxOnlyNotEquipped()
+    {
+        return false;
+    }
+
+    @ConfigItem(
 		keyName = "ringOfLifeNotification",
 		name = "Ring of life notification",
 		description = "Notify when Ring of life is destroyed"

--- a/src/main/java/com/molopl/plugins/lifesaving/LifeSavingInfoBox.java
+++ b/src/main/java/com/molopl/plugins/lifesaving/LifeSavingInfoBox.java
@@ -33,30 +33,30 @@ import net.runelite.client.ui.overlay.infobox.InfoBox;
 @Getter
 public class LifeSavingInfoBox extends InfoBox
 {
-	private final LifeSavingItem type;
+    private final LifeSavingItem type;
 
-	public LifeSavingInfoBox(Plugin plugin, BufferedImage image, LifeSavingItem type, String name)
-	{
-		super(image, plugin);
-		this.type = type;
-		setTooltip(name);
-	}
+    public LifeSavingInfoBox(Plugin plugin, BufferedImage image, LifeSavingItem type, String name)
+    {
+        super(image, plugin);
+        this.type = type;
+        setTooltip(name);
+    }
 
-	@Override
-	public String getText()
-	{
-		return "";
-	}
+    @Override
+    public String getText()
+    {
+        return "";
+    }
 
-	@Override
-	public Color getTextColor()
-	{
-		return Color.WHITE;
-	}
+    @Override
+    public Color getTextColor()
+    {
+        return Color.WHITE;
+    }
 
-	@Override
-	public String getName()
-	{
-		return super.getName() + "_" + type.name();
-	}
+    @Override
+    public String getName()
+    {
+        return super.getName() + "_" + type.name();
+    }
 }

--- a/src/main/java/com/molopl/plugins/lifesaving/LifeSavingPlugin.java
+++ b/src/main/java/com/molopl/plugins/lifesaving/LifeSavingPlugin.java
@@ -145,34 +145,80 @@ public class LifeSavingPlugin extends Plugin
 		updateInfobox(config.phoenixNecklaceInfobox(), LifeSavingItem.PHOENIX_NECKLACE, items);
 	}
 
-	private void updateInfobox(boolean enabled, LifeSavingItem type, Item[] wornItems)
-	{
-		if (!enabled)
-		{
-			return;
-		}
+    private static BufferedImage tintImageRed(BufferedImage src, int alpha)
+    {
+        // Clamp alpha to [0,255]
+        alpha = Math.max(0, Math.min(255, alpha));
 
-		removeInfobox(type);
+        BufferedImage dst = new BufferedImage(src.getWidth(), src.getHeight(), BufferedImage.TYPE_INT_ARGB);
+        java.awt.Graphics2D g = dst.createGraphics();
+        try
+        {
+            g.drawImage(src, 0, 0, null);
+            g.setComposite(java.awt.AlphaComposite.SrcAtop);
+            g.setColor(new java.awt.Color(255, 0, 0, alpha));
+            g.fillRect(0, 0, src.getWidth(), src.getHeight());
+        }
+        finally
+        {
+            g.dispose();
+        }
+        return dst;
+    }
 
-		final int itemId = type.getItemId();
-		final int slotIdx = type.getSlot().getSlotIdx();
+    private void updateInfobox(boolean enabled, LifeSavingItem type, Item[] wornItems)
+    {
+        if (!enabled)
+        {
+            removeInfobox(type);
+            return;
+        }
 
-		if (wornItems.length <= slotIdx)
-		{
-			return;
-		}
+        // Idempotent: clear then add if needed
+        removeInfobox(type);
 
-		final Item wornItem = wornItems[slotIdx];
-		if (wornItem.getId() != itemId)
-		{
-			return;
-		}
+        final int itemId = type.getItemId();
+        final int slotIdx = type.getSlot().getSlotIdx();
 
-		final String name = itemManager.getItemComposition(itemId).getName();
-		final BufferedImage image = itemManager.getImage(itemId);
-		final LifeSavingInfoBox infobox = new LifeSavingInfoBox(this, image, type, name);
-		infoBoxManager.addInfoBox(infobox);
-	}
+        boolean equipped = false;
+        if (wornItems != null && wornItems.length > slotIdx)
+        {
+            final Item wornItem = wornItems[slotIdx];
+            equipped = (wornItem != null && wornItem.getId() == itemId);
+        }
+
+        // Default behavior: show when equipped
+        boolean wantInfobox = equipped;
+
+        // If toggle is ON and this is RoL, invert (show only when NOT equipped)
+        if (type == LifeSavingItem.RING_OF_LIFE && config.ringOfLifeInfoboxOnlyNotEquipped())
+        {
+            wantInfobox = !equipped;
+        }
+
+        if (!wantInfobox)
+        {
+            return;
+        }
+
+        // Always-red mode while in NOT-equipped branch for RoL
+        final boolean redMode =
+                (type == LifeSavingItem.RING_OF_LIFE)
+                        && config.ringOfLifeInfoboxOnlyNotEquipped()
+                        && !equipped;
+
+        // Build the image (tinted if redMode)
+        BufferedImage image = itemManager.getImage(itemId);
+        if (redMode)
+        {
+            image = tintImageRed(image, 90); // alpha 0..255; 90 ≈ 35% opacity
+        }
+
+        final String itemName = itemManager.getItemComposition(itemId).getName();
+        final LifeSavingInfoBox infobox = new LifeSavingInfoBox(this, image, type, itemName);
+        infoBoxManager.addInfoBox(infobox);
+    }
+
 
 	private void removeInfobox(final LifeSavingItem type)
 	{


### PR DESCRIPTION
Notes:
- Boolean is set to false by default, so plugin functionality is not changed unless enabled
- When enabled:
  - Infobox only appears when the RoL is NOT equipped (to serve as a reminder for HCIM players to equip it)
  - RoL has a red tint to indicate urgency