### PR TITLE
Add sailing lantern fishing fish

### DIFF
--- a/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
+++ b/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
@@ -117,6 +117,8 @@ public class FishBarrelPlugin extends Plugin
 		.put("anglerfish", ItemID.RAW_ANGLERFISH)
 		.put("dark crab", ItemID.RAW_DARK_CRAB)
 		.put("sacred eel", ItemID.SNAKEBOSS_EEL)
+		.put("swordtip squid", ItemID.SWORDTIP_SQUID)
+		.put("jumbo squid", ItemID.JUMBO_SQUID)
 		.build();
 
 	// a set of possible fish caught with a cormorant on Molch island


### PR DESCRIPTION
New sailing fish aren't supported in fish barrel. The 25 was from a manual "Check", but its actually full and generally not updating. 

I assume there's more sailing fish also not supported, but I don't know exactly which ones yet.

<img width="1213" height="400" alt="squids" src="https://github.com/user-attachments/assets/a2fcf7b8-bfca-49d3-a68d-997074e064f7" />
