### PR TITLE
Fish barrel fix

### DIFF
--- a/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelConfig.java
+++ b/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelConfig.java
@@ -37,7 +37,7 @@ public interface FishBarrelConfig extends Config {
     @ConfigItem(
             keyName = "overlayColor",
             name = "Overlay Color",
-            description = "Color used for the barrel overlay that displays the fish count",
+            description = "Color used for the barrel overlay that displays the fish count.",
             position = 1
     )
     default Color overlayColor()

--- a/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelConfig.java
+++ b/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelConfig.java
@@ -37,7 +37,7 @@ public interface FishBarrelConfig extends Config {
     @ConfigItem(
             keyName = "overlayColor",
             name = "Overlay Color",
-            description = "Color used for the barrel overlay that displays the fish count.",
+            description = "Color used for the barrel overlay that displays the fish count",
             position = 1
     )
     default Color overlayColor()

--- a/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
+++ b/src/main/java/com/molopl/plugins/fishbarrel/FishBarrelPlugin.java
@@ -85,6 +85,7 @@ public class FishBarrelPlugin extends Plugin
 
 	private static final String BANK_FULL_MESSAGE = "Your bank could not hold your fish.";
 	private static final String BARREL_FULL_MESSAGE = "The barrel is full. It may be emptied at a bank.";
+	private static final String BANK_EMPTY_MESSAGE = "You empty all of your containers into the bank.";
 
 	// maps the name of the fish as it appears in chat message to corresponding item ID
 	private static final Map<String, Integer> FISH_TYPES_BY_NAME = ImmutableMap.<String, Integer>builder()
@@ -216,6 +217,9 @@ public class FishBarrelPlugin extends Plugin
 					FishBarrel.STATE.setHolding(FishBarrel.CAPACITY);
 					FishBarrel.STATE.setUnknown(false);
 					break;
+				case BANK_EMPTY_MESSAGE:
+					FishBarrel.STATE.setHolding(0);
+					FishBarrel.STATE.setUnknown(false);
 			}
 		}
 		else if (event.getType() == ChatMessageType.SPAM && hasAnyOfItems(FishBarrel.OPEN_BARREL_IDS))


### PR DESCRIPTION
Added in a fix so that the fish barrel properly empties when you click the "empty container" button on the bank by parsing the chat.

Feel like there's a better way of implementing it but a more robust solution can be developed once Jagex is done making the lock slot options with regards to containers.